### PR TITLE
Removal of Localized functions

### DIFF
--- a/LoggerHead.lua
+++ b/LoggerHead.lua
@@ -5,16 +5,6 @@ local LDB = LibStub("LibDataBroker-1.1", true)
 local LDBIcon = LDB and LibStub("LibDBIcon-1.0", true)
 local LoggerHeadDS
 
--- Localize a few functions
-
-local LoggingCombat = _G.LoggingCombat
-local LoggingChat = _G.LoggingChat
-local IsAddOnLoaded = _G.IsAddOnLoaded
-local GetInstanceInfo = _G.GetInstanceInfo
-local pairs = _G.pairs
-local tonumber = _G.tonumber
-local string = _G.string
-
 local enabled_text = GREEN_FONT_COLOR_CODE..VIDEO_OPTIONS_ENABLED..FONT_COLOR_CODE_CLOSE
 local disabled_text = RED_FONT_COLOR_CODE..VIDEO_OPTIONS_DISABLED..FONT_COLOR_CODE_CLOSE
 local enabled_icon  = "Interface\\AddOns\\"..ADDON_NAME.."\\enabled"


### PR DESCRIPTION
I am currently looking into the tracking of addons that enable and disable Combat Logging sadly the localization of the functions make it impossible to be hooked for a addon or script that loads after loggerhead. The optimization gain of the localization is minimal anyway. I also removed the other localized functions where some werent even used.

I hope you can accept the PR and this wasnt to bad.